### PR TITLE
Revert "template: switch to virtio"

### DIFF
--- a/templates/windows/.gitignore
+++ b/templates/windows/.gitignore
@@ -4,5 +4,3 @@ venv/
 output-windows/
 # packer vagrant post-processor output
 *.box
-# virtio ISO
-virtio-win.iso

--- a/templates/windows/Vagrantfile_template
+++ b/templates/windows/Vagrantfile_template
@@ -15,6 +15,8 @@ Vagrant.configure("2") do |config|
   # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1743
   config.vagrant.plugins = {"vagrant-libvirt" => {"version" => "0.11.2"}}
   config.vm.provider :libvirt do |libvirt|
+    libvirt.disk_bus = "ide"
+    libvirt.nic_model_type = "e1000e"
     libvirt.memory = 4096
   end
 end

--- a/templates/windows/answer_files/10/Autounattend.xml
+++ b/templates/windows/answer_files/10/Autounattend.xml
@@ -62,16 +62,6 @@
             <UILanguageFallback>en-US</UILanguageFallback>
             <UserLocale>en-US</UserLocale>
         </component>
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-                <Path>E:\NetKVM\w10\amd64\</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                <Path>E:\viostor\w10\amd64\</Path>
-                </PathAndCredentials>
-            </DriverPaths>
-        </component>
     </settings>
     <settings pass="offlineServicing">
         <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/templates/windows/windows.pkr.hcl
+++ b/templates/windows/windows.pkr.hcl
@@ -86,7 +86,7 @@ source "qemu" "windows" {
   communicator     = "winrm"
   cpus             = "${var.cpus}"
   disk_compression = false
-  disk_interface   = "virtio"
+  disk_interface   = "ide"
   disk_size        = "${var.disk_size}"
   floppy_files     = ["${var.autounattend}", "scripts/fixnetwork.ps1", "scripts/setup_winrm_public.bat"]
   format           = "qcow2"
@@ -96,10 +96,9 @@ source "qemu" "windows" {
   memory           = "${var.memory}"
   qemuargs         = [
     ["-usb"],
-    ["-device", "usb-tablet"],
-    ["-cdrom", "./virtio-win.iso"]
+    ["-device", "usb-tablet"]
   ]
-  net_device       = "virtio-net"
+  net_device       = "rtl8139"
   shutdown_command = "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\""
   skip_compaction  = true
   vm_name          = "${var.vm_name}.qcow2"

--- a/windows_x86_64/kafl.yaml
+++ b/windows_x86_64/kafl.yaml
@@ -1,5 +1,5 @@
 # null qemu_append
 qemu_append: ''
 qemu_memory: 4096
-qemu_image: '@format {env[HOME]}/.local/share/libvirt/images/windows_x86_64_vagrant-kafl-windows.img,if=virtio'
+qemu_image: '@format {env[HOME]}/.local/share/libvirt/images/windows_x86_64_vagrant-kafl-windows.img'
 qemu_extra: '-monitor unix:/tmp/monitor.sock,server,nowait'


### PR DESCRIPTION
This reverts commit 8ef3d33022917ddb24610730b6817fac410882a2

Because of repeated virtio failures, virtio is not reliable yet.
Maybe need to upgrade QEMU
Related https://github.com/IntelLabs/kafl.qemu/issues/11