### PR TITLE
windows: add packer init

### DIFF
--- a/templates/windows/Makefile
+++ b/templates/windows/Makefile
@@ -10,6 +10,7 @@ $(ROOT_DIR)/venv/bin/ansible-playbook:
 ansible: $(ROOT_DIR)/venv/bin/ansible-playbook
 
 build: ansible virtio-win.iso
+	packer init windows.pkr.hcl
 	source $(ROOT_DIR)/venv/bin/activate && packer build -var-file win10.pkrvars.hcl windows.pkr.hcl
 
 import:

--- a/templates/windows/windows.pkr.hcl
+++ b/templates/windows/windows.pkr.hcl
@@ -7,6 +7,24 @@
 # once they also need to be in the same folder. 'packer inspect folder/'
 # will describe to you what is in that folder.
 
+packer {
+  required_plugins {
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = "~> 1"
+    }
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = "~> 1"
+    }
+    vagrant = {
+      source  = "github.com/hashicorp/vagrant"
+      version = "~> 1"
+    }
+  }
+}
+
+
 # Avoid mixing go templating calls ( for example ```{{ upper(`string`) }}``` )
 # and HCL2 calls (for example '${ var.string_value_example }' ). They won't be
 # executed together and the outcome will be unknown.


### PR DESCRIPTION
Will be required in a future version of Packer where bundled plugins will be removed