### PR TITLE
windows: force CPU topology in Vagrant

### DIFF
--- a/windows_x86_64/Vagrantfile
+++ b/windows_x86_64/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure("2") do |config|
         # spice is better than VNC (mouse handling)
         libvirt.graphics_type = "spice"
         libvirt.cpus = 4
+        libvirt.cputopology :sockets => '1', :cores => '4', :threads => '1'
         libvirt.memory = 4096
     end
 


### PR DESCRIPTION
this avoids increasing the libvirt.cpus value, which only ends up increzasing the amount of sockets assigned to the VM

Windows 10 can only manage up top 4 CPU sockets

fixes https://github.com/IntelLabs/kAFL/issues/241