### PR TITLE
windows: unset HTTP_PROXY before Vagrant attempts WinRM connection

### DIFF
--- a/windows_x86_64/Vagrantfile
+++ b/windows_x86_64/Vagrantfile
@@ -11,6 +11,16 @@ Vagrant.configure("2") do |config|
 
     # rsync doesn't work on WinRM
     config.vm.synced_folder ".", "/vagrant", disabled: true
+
+    # Vagrant WinRM lib uses HTTP_PROXY even if destination is on local network
+    config.trigger.before :up do |trigger|
+        trigger.info = "Unset HTTP_PROXY"
+        ENV['HTTP_PROXY'] = nil
+        ENV['HTTPS_PROXY'] = nil
+        ENV['http_proxy'] = nil
+        ENV['https_proxy'] = nil
+    end
+
     config.vm.provider :libvirt do |libvirt|
         # the qcow will be owned by the user
         # so kafl can use the VM's qcow as well


### PR DESCRIPTION
If the environment defines an `HTTP/S_PROXY`, the WinRM library used by Vagrant will pick it up to reach the host, even if the target is on the local network.

Add a trigger to undefine the proxy in the environment.