### PR TITLE
windows: set packer vagrant post-processor output filename

### DIFF
--- a/templates/windows/windows.pkr.hcl
+++ b/templates/windows/windows.pkr.hcl
@@ -148,5 +148,6 @@ build {
   }
   post-processor "vagrant" {
     vagrantfile_template = "Vagrantfile_template"
+    output = "packer_{{.BuildName}}_{{.Provider}}.box"
   } 
 }


### PR DESCRIPTION
Since packer vagrant post-processor [`v1.1.0`](https://developer.hashicorp.com/packer/integrations/hashicorp/vagrant/v1.1.0/components/post-processor/vagrant) the default output box name contains an additional Architecture field:

`By default, the value of this config is packer_{{.BuildName}}_{{.Provider}}_{{.Architecture}}.box.`

Remomve this field for compatibility and force the output name to the old behavior.