### PR TITLE
scripts: fix busybox static detection

### DIFF
--- a/linux-user/scripts/Makefile
+++ b/linux-user/scripts/Makefile
@@ -16,4 +16,6 @@ $(VMCALL_BIN):
 
 # gen_initrd.sh depends on vmcall
 $(TARGET): $(MAKEF_DIR)/gen_initrd.sh $(VMCALL_BIN) 
-	$< $@ $(VMCALL_BIN)
+	# Run gen_initrd.sh outside of the virtual environment
+	# lddtree is a python script that depends on globally installed packages
+	env -u VIRTUAL_ENV -u PATH $< $@ $(VMCALL_BIN)

--- a/linux-user/scripts/gen_initrd.sh
+++ b/linux-user/scripts/gen_initrd.sh
@@ -97,7 +97,7 @@ test -d "$TEMPLATE" || fatal "Could not find initrd template folder >>$TEMPLATE<
 BUSYBOX=$(which busybox) || fatal "Could not find busybox - try 'sudo apt install busybox-static'?"
 LDDTREE=$(which lddtree) || fatal "Could not find lddtree - try 'sudo apt install lddtree'?"
 
-$LDDTREE $BUSYBOX |grep -q "interpreter => none" || fatal "Binary at $BUSYBOX is not static. Try 'apt install busybox-static'."
+$LDDTREE $BUSYBOX |grep -qi "interpreter => none" || fatal "Binary at $BUSYBOX is not static. Try 'apt install busybox-static'."
 
 TARGET_INITRD="$(realpath "$1")"; shift;
 TARGET_ROOT="$(mktemp -d)"


### PR DESCRIPTION
lddtree has a dependency on elftools, and shouldn't be inside the virtualenv
~~~python
Traceback (most recent call last):
  File "/bin/lddtree", line 53, in <module>
    from elftools.elf.elffile import ELFFile
ImportError: No module named elftools.elf.elffile
~~~

deactivate the virtualenv before running `gen_initrd.sh`

related: https://github.com/IntelLabs/kAFL/issues/306