### PR TITLE
windows: remove unused vagrant-host-shell plugin

### DIFF
--- a/templates/windows/Vagrantfile_template
+++ b/templates/windows/Vagrantfile_template
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins = ["vagrant-libvirt", "vagrant-host-shell"]
+  config.vagrant.plugins = ["vagrant-libvirt"]
 
   # The Packer box we just added
   config.vm.box = "kafl_windows"


### PR DESCRIPTION
We rely on vagrant-triggers since 842357e338c22cfdd8fa9cedb41a1cc243271678