### PR TITLE
Linux user/initrd modules

### DIFF
--- a/linux-user/dvkm/.gitignore
+++ b/linux-user/dvkm/.gitignore
@@ -2,3 +2,8 @@
 sharedir/dvkm.ko
 sharedir/fuzz_dvkm
 
+Module.symvers
+modules.order
+.modules.order.cmd
+.Module.symvers.cmd
+

--- a/linux-user/dvkm/Makefile
+++ b/linux-user/dvkm/Makefile
@@ -8,6 +8,7 @@ MAKEF_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 EXAMPLES_ROOT := $(KAFL_ROOT)/examples
 LINUX_AGENT_DIR := $(EXAMPLES_ROOT)/linux-user/linux_kafl_agent
 GEN_INITRD_DIR := $(EXAMPLES_ROOT)/linux-user/scripts
+INITRD_MODULES_STAGING_DIR := $(GEN_INITRD_DIR)/modules
 DVKM_DIR := $(MAKEF_DIR)/Damn_Vulnerable_Kernel_Module
 
 # Artifacts
@@ -38,8 +39,11 @@ $(LINUX_AGENT_BZIMAGE):
 	$(MAKE) -C $(LINUX_AGENT_DIR) olddefconfig
 	$(MAKE) -C $(LINUX_AGENT_DIR) -j $(shell nproc)
 
+modules: $(LINUX_AGENT_BZIMAGE)
+	$(MAKE) -C $(LINUX_AGENT_DIR) modules_install INSTALL_MOD_PATH=$(INITRD_MODULES_STAGING_DIR)
+
 # Build initrd
-$(KAFL_INITRD_PATH):
+$(KAFL_INITRD_PATH): modules
 	$(MAKE) -C $(GEN_INITRD_DIR)
 
 # Build dvkm.ko (and test_dvkm)

--- a/linux-user/scripts/.gitignore
+++ b/linux-user/scripts/.gitignore
@@ -1,2 +1,4 @@
 # ignore build output
 *.cpio.gz
+
+modules/

--- a/linux-user/scripts/Makefile
+++ b/linux-user/scripts/Makefile
@@ -9,6 +9,7 @@ all: $(TARGET)
 
 clean:
 	rm -f $(TARGET)
+	rm -rf $(MAKEF_DIR)/modules
 
 # build vmcall if needed
 $(VMCALL_BIN):

--- a/linux-user/scripts/gen_initrd.sh
+++ b/linux-user/scripts/gen_initrd.sh
@@ -18,8 +18,10 @@
 set -e
 set -u
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SCRIPT_ROOT=$EXAMPLES_ROOT/linux-user
 TEMPLATE=$SCRIPT_ROOT/initrd_template
+MODULES_STAGING_DIR=$SCRIPT_DIR/modules
 
 fatal() {
 	echo
@@ -76,6 +78,11 @@ function inject_files()
 		echo "Install $dep => $TARGET_ROOT/$dep"
 		install -D "$dep" $TARGET_ROOT/"$dep"
 	done
+
+	if [ -d "$MODULES_STAGING_DIR" ]; then
+		echo "[*] Copying modules..."
+		rsync -av "$MODULES_STAGING_DIR/" "$TARGET_ROOT/"
+	fi
 }
 
 function build_image()


### PR DESCRIPTION
This PR installs the kernel module in the initrd generated by `linux-user/scripts/gen_initrd.sh`, so we can `insmod module.ko` in `linux-user/dvkm/sharedir/agent.sh`